### PR TITLE
return address on create basket

### DIFF
--- a/src/BasketFactory.sol
+++ b/src/BasketFactory.sol
@@ -9,11 +9,13 @@ contract BasketFactory {
     
     event NewBasket(address indexed _address, address indexed _creator);
     
-    function createBasket() public {
+    function createBasket() public returns(address) {
         Basket basket = new Basket();
         basket.transferFrom(address(this), msg.sender, 0);
         baskets.push(address(basket));
         emit NewBasket(address(basket), msg.sender);
+
+        return address(basket);
     }
     
 }


### PR DESCRIPTION
I think it makes life a bit easier for programmatic deployments if the address is returned on `createBasket`. 
Furthermore, I doubt it would have any effect on anything else. However, I'd love to get feedback on this.